### PR TITLE
Move feature tag into dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ readme = "README.md"
 
 [dependencies.sdl2]
 git = "https://github.com/AngryLawyer/rust-sdl2"
+
+[dependencies]
+libc = "0.2.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(libc)]
-
 extern crate libc;
 
 use libc::c_void;


### PR DESCRIPTION
I had the problem that I used to get the following error message when trying to compile a project with rust-sdl2_net as a dependency:

```
src/lib.rs:1:1: 1:18 error: #[feature] may not be used on the stable release channel
src/lib.rs:1 #![feature(libc)]
             ^~~~~~~~~~~~~~~~~
error: aborting due to previous error
Could not compile `sdl2_net`.
```

Therefore, I moved said feature tag out of lib.rs and put a dependency on libc into Cargo.toml, and now it works for me.
